### PR TITLE
Change HTTP links to HTTPS

### DIFF
--- a/curriculum.html
+++ b/curriculum.html
@@ -12,10 +12,10 @@
 <div class="bg-white mt-3 mb-4">
   <h1 class="w-full text-lg text-teal-100 tracking-widest text-left h-15 bg-tml-blue p-2">Review questions - curriculum topics</h1>
     <div class="flex flex-col md:flex-row flex-wrap justify-between mt-5">
-        <a href="http://www.realscience.org.uk/3ml/pdfs/QuestionsForces.pdf" target="_blank" rel="noopener noreferrer" class="w-full md:w-1/2 text-md hover:text-tml-blue">
+        <a href="https://www.realscience.org.uk/3ml/pdfs/QuestionsForces.pdf" target="_blank" rel="noopener noreferrer" class="w-full md:w-1/2 text-md hover:text-tml-blue">
             <div class="flex w-full md:w-11/12 md:mx-auto h-40 md:h-40 bg-white p-6 shadow-md hover:shadow-xl mb-8">
                 <div class="w-30 h-30 flex-none mr-3 sm:mr-5">
-                    <img class="rounded" src="http://www.realscience.org.uk/3ml/img/liftthumb.jpg" alt="Forces on an aeroplane">
+                    <img class="rounded" src="https://www.realscience.org.uk/3ml/img/liftthumb.jpg" alt="Forces on an aeroplane">
                 </div>
                 <div class="text-left">
                     <h2 class="text-lg">Forces</h2>

--- a/help_videos.txt
+++ b/help_videos.txt
@@ -1,12 +1,12 @@
-How to search for stories,http://www.realscience.org.uk/3ml/vids/2findastory.mp4
-How to do connect and question,http://www.realscience.org.uk/3ml/vids/3connectandquestion.mp4
-How to do summarise and clarify,http://www.realscience.org.uk/3ml/vids/4summariseandclarfiy.mp4
-How to register your school for 3ml,http://www.realscience.org.uk/3ml/vids/6registeringaschool.mp4
-How to calculate the readability of a piece of writing,http://www.realscience.org.uk/3ml/vids/5findingtheflesch.mp4
-How to make accounts for your pupils,http://www.realscience.org.uk/3ml/vids/7makingpupilsaccounts.mp4
-How to collect pupils into a class,http://www.realscience.org.uk/3ml/vids/8makingaclass.mp4
-How to make an anthology of stories for pupils,http://www.realscience.org.uk/3ml/vids/9makingananthology.mp4
-How to make accounts for other teachers,http://www.realscience.org.uk/3ml/vids/10extrateacheraccounts.mp4
-How to set or change a pupil password,http://www.realscience.org.uk/3ml/vids/11NewPupilPassword.mp4
-Motivation: Why 3ml?,http://www.realscience.org.uk/3ml/vids/0Why3ml.mp4
-How hard it is to find readable science stories?,http://www.realscience.org.uk/3ml/vids/1findingsciencestories.mp4
+How to search for stories,https://www.realscience.org.uk/3ml/vids/2findastory.mp4
+How to do connect and question,https://www.realscience.org.uk/3ml/vids/3connectandquestion.mp4
+How to do summarise and clarify,https://www.realscience.org.uk/3ml/vids/4summariseandclarfiy.mp4
+How to register your school for 3ml,https://www.realscience.org.uk/3ml/vids/6registeringaschool.mp4
+How to calculate the readability of a piece of writing,https://www.realscience.org.uk/3ml/vids/5findingtheflesch.mp4
+How to make accounts for your pupils,https://www.realscience.org.uk/3ml/vids/7makingpupilsaccounts.mp4
+How to collect pupils into a class,https://www.realscience.org.uk/3ml/vids/8makingaclass.mp4
+How to make an anthology of stories for pupils,https://www.realscience.org.uk/3ml/vids/9makingananthology.mp4
+How to make accounts for other teachers,https://www.realscience.org.uk/3ml/vids/10extrateacheraccounts.mp4
+How to set or change a pupil password,https://www.realscience.org.uk/3ml/vids/11NewPupilPassword.mp4
+Motivation: Why 3ml?,https://www.realscience.org.uk/3ml/vids/0Why3ml.mp4
+How hard it is to find readable science stories?,https://www.realscience.org.uk/3ml/vids/1findingsciencestories.mp4

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
         Three Minute Learning is a social enterprise set up to improve literacy and promote real science in schools.
     </h1>
     <video controls class="w-full md:w-1/2 mb-4">
-        <source src="http://www.realscience.org.uk/3ml/vids/timpeake.mp4" type="video/mp4">
+        <source src="https://www.realscience.org.uk/3ml/vids/timpeake.mp4" type="video/mp4">
         Your browser does not support the video tag.
     </video>
     <!-- Intro-->

--- a/researchers.txt
+++ b/researchers.txt
@@ -1,6 +1,6 @@
-Jane Goodall,http://www.realscience.org.uk/3ml/img/janethumb2.jpg,http://www.realscience.org.uk/3ml/pdfs/QuestionsJaneGoodall.pdf,Jane is the world's leading expert on wild chimpanzees.
-Dawn Geatches,http://www.realscience.org.uk/3ml/img/dawnthumb.jpg,http://www.realscience.org.uk/3ml/pdfs/QuestionsDawnGeatches.pdf,Dawn is a scientist at Daresbury Laboratory. (Take a look at her story 'The In-betweeners').
-Valeria Losasso,http://www.realscience.org.uk/3ml/img/valeriathumb.jpg,http://www.realscience.org.uk/3ml/pdfs/QuestionsValeriaLosasso.pdf,Valeria is a scientist at Daresbury Laboratory.
-James Wilson,http://www.realscience.org.uk/3ml/img/jameswilsonthumb.jpg,http://www.realscience.org.uk/3ml/pdfs/QuestionsJamesWilson.pdf,James is an engineer at Daresbury Laboratory.
-James Gebbie,http://www.realscience.org.uk/3ml/img/jamesgebbiethumb.jpg,http://www.realscience.org.uk/3ml/pdfs/QuestionsJamesGebbie,James is a computer scientist at Daresbury Laboratory.
-Chris Pearson,http://www.realscience.org.uk/3ml/img/chrispearsonthumb.jpg,http://www.realscience.org.uk/3ml/pdfs/QuestionsChrisPearson.pdf,Chris is an astronomer at RAL Space.
+Jane Goodall,https://www.realscience.org.uk/3ml/img/janethumb2.jpg,https://www.realscience.org.uk/3ml/pdfs/QuestionsJaneGoodall.pdf,Jane is the world's leading expert on wild chimpanzees.
+Dawn Geatches,https://www.realscience.org.uk/3ml/img/dawnthumb.jpg,https://www.realscience.org.uk/3ml/pdfs/QuestionsDawnGeatches.pdf,Dawn is a scientist at Daresbury Laboratory. (Take a look at her story 'The In-betweeners').
+Valeria Losasso,https://www.realscience.org.uk/3ml/img/valeriathumb.jpg,https://www.realscience.org.uk/3ml/pdfs/QuestionsValeriaLosasso.pdf,Valeria is a scientist at Daresbury Laboratory.
+James Wilson,https://www.realscience.org.uk/3ml/img/jameswilsonthumb.jpg,https://www.realscience.org.uk/3ml/pdfs/QuestionsJamesWilson.pdf,James is an engineer at Daresbury Laboratory.
+James Gebbie,https://www.realscience.org.uk/3ml/img/jamesgebbiethumb.jpg,https://www.realscience.org.uk/3ml/pdfs/QuestionsJamesGebbie,James is a computer scientist at Daresbury Laboratory.
+Chris Pearson,https://www.realscience.org.uk/3ml/img/chrispearsonthumb.jpg,https://www.realscience.org.uk/3ml/pdfs/QuestionsChrisPearson.pdf,Chris is an astronomer at RAL Space.


### PR DESCRIPTION
The realscience site now has HTTPS enabled so the links will work
with the current 3ml Content Security Policy. Previously embedded
content would not load on the live site.